### PR TITLE
Minor fixes

### DIFF
--- a/mkdocs_obsidian_bridge/plugin.py
+++ b/mkdocs_obsidian_bridge/plugin.py
@@ -256,7 +256,7 @@ class ObsidianBridgePlugin(BasePlugin[ObsidianBridgeConfig]):
         #   n + 0: regular text
         #   n + 1: text in backticks, e.g. ```some code```, or <pre>, or <code>
         #   n + 2: actual number of backtics, e.g. ```
-        CODE_BLOCK = re.compile(r'((`+).+?\2|<pre>.+?</pre>|<code>.+?</code>)')
+        CODE_BLOCK = re.compile(r'((`+).+?\2|<pre>.+?</pre>|<code>.+?</code>)', re.DOTALL)
         raw_chunks = re.split(CODE_BLOCK, markdown)
 
         processed_chunks = [

--- a/mkdocs_obsidian_bridge/plugin.py
+++ b/mkdocs_obsidian_bridge/plugin.py
@@ -116,7 +116,6 @@ class ObsidianBridgePlugin(BasePlugin[ObsidianBridgeConfig]):
     def best_path(self, page_dir: Path, candidates: list[Path]) -> Path:
         '''Return the shortest path from the list of path candidates relatively to the page_dir.'''
         assert page_dir.is_absolute()
-        assert len(candidates) > 0
         assert all(c.is_absolute() for c in candidates)
 
         match len(candidates):
@@ -133,6 +132,9 @@ class ObsidianBridgePlugin(BasePlugin[ObsidianBridgeConfig]):
                 raise NoCandidatesError()
 
     def find_best_path(self, link_filepath: Path, page_path: Path) -> Path | None:
+        def match_link_filepath(p: Path) -> bool:
+            return p.as_posix().endswith(link_filepath.as_posix())
+
         assert page_path.is_absolute()
         assert self.file_map is not None
 
@@ -148,7 +150,9 @@ class ObsidianBridgePlugin(BasePlugin[ObsidianBridgeConfig]):
             return
 
         page_dir = page_path.parent
-        path_candidates = self.file_map[link_filepath.name]
+        # filter the list of all candidates for the filename, so that only those with a match of the filepath
+        # from the link are left
+        path_candidates = [p for p in self.file_map[link_filepath.name] if match_link_filepath(p)]
         try:
             return self.best_path(page_dir, path_candidates)
         except NoCandidatesError:

--- a/mkdocs_obsidian_bridge/plugin.py
+++ b/mkdocs_obsidian_bridge/plugin.py
@@ -292,7 +292,7 @@ class ObsidianBridgePlugin(BasePlugin[ObsidianBridgeConfig]):
                 new_suffix = link_filepath.suffix + '.md'
                 new_path = self.find_best_path(link_filepath.with_suffix(new_suffix), page_path)
 
-            alternative_label: str = matched_filepath + self.slugify(match['fragment'])
+            alternative_label: str = matched_filepath + (match['fragment'] or '')
             new_link = f'''[{
                 match['label'] or alternative_label
             }]({

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mkdocs-obsidian-bridge"
-version = "1.0.0"
+version = "1.0.1"
 description = "An MkDocs plugin that helps exporting your Obsidian vault as an MkDocs site."
 authors = ["GooRoo <sergey.olendarenko@gmail.com>"]
 license = "BSD-3-Clause"


### PR DESCRIPTION
- Fix code-blocks detections (#5).
- Fix incorrect handling of `index.md`/`README.md` (#4).
- Fix incorrect rendering of obsidian links with fragments.
    For example, for a link `[[Page name#Some header]]` the following link was generated (with default `slugify`):
    [Page name#some-header]()
    Now it renders it the same way as Obsidian does:
    [Page name#Some header]()